### PR TITLE
One little fix

### DIFF
--- a/lib/Translator.js
+++ b/lib/Translator.js
@@ -166,7 +166,7 @@
       if (language == null) {
         language = this.language;
       }
-      categoryName = _path + '/' + name;
+      categoryName = _path + '/' + language +'.'+ name;
       if (typeof this.data[categoryName] === 'undefined') {
         if (this.cache === null) {
           data = this.loader.load(_path, name, language);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translator",
 	"description": "[ABANDONED] Translator for node and also for browser",
-	"version": "1.9.1",
+	"version": "1.9.2",
 	"author": {
 		"name": "David Kudera",
 		"email": "kudera.d@gmail.com"

--- a/src/Translator.coffee
+++ b/src/Translator.coffee
@@ -141,7 +141,7 @@ class Translator
 
 
 	loadCategory: (_path, name, language = @language) ->
-		categoryName = _path + '/' + name
+		categoryName = _path + '/' + language +'.'+ name;
 		if typeof @data[categoryName] == 'undefined'
 			if @cache == null
 				data = @loader.load(_path, name, language)

--- a/test/node/lib/Translator.cache.js
+++ b/test/node/lib/Translator.cache.js
@@ -40,7 +40,7 @@
       it('should load translation from cache', function() {
         var t;
         translator.translate('web.pages.homepage.promo.title');
-        t = translator.cache.load('en:web/pages/homepage/promo');
+        t = translator.cache.load('en:web/pages/homepage/en.promo');
         expect(t).to.be.an('object');
         return expect(t).to.include.keys('title');
       });


### PR DESCRIPTION
to work with different languages were added some changes, because earlier we were able to load only one file: 
"en.example.json" or "ru.example.json", key example in data object was replaced to {locale}.example
